### PR TITLE
Completely define ngOnChanges function signature

### DIFF
--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -11,6 +11,7 @@ import {
     EventEmitter,
     ViewContainerRef,
     ModuleWithProviders,
+    SimpleChanges
 } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
@@ -85,7 +86,7 @@ export class VirtualScrollComponent implements OnDestroy, OnChanges {
         this.onScrollListener = this.renderer.listen(this.element.nativeElement, 'scroll', this.refresh.bind(this));
     }
 
-    ngOnChanges() {
+    ngOnChanges(changes: SimpleChanges) {
         this.previousStart = undefined;
         this.previousEnd = undefined;
         this.refresh();


### PR DESCRIPTION
`ngc` with AOT fails to build when the `ngOnChanges` is not completely defined