### PR TITLE
ensure that onScrollListener is actually defined before removing

### DIFF
--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -102,7 +102,13 @@ export class VirtualScrollComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   ngOnDestroy() {
-    this.onScrollListener();
+    // Check that listener has been attached properly:
+    // It may be undefined in some cases, e.g. if an exception is thrown, the component is
+    // not initialized properly but destroy may be called anyways (e.g. in testing).
+    if (this.onScrollListener !== undefined) {
+      // this removes the listener
+      this.onScrollListener();
+    }
   }
 
   refresh() {


### PR DESCRIPTION
I had a problem when using VirtualScrollComponent in my application and writing tests. A single test containing the VirtualScrollComponent failed (see below) and as a results all following tests also failed. It was very hard to find out the actual problem but I think I could figure out the original cause.

Repro:
1. Use VirtualScrollComponent in template of another component e.g. called MyComponent
2. Write a test for MyComponent that checks whether an error is thrown when something is not initialized properly, e.g.
`  it('should throw if no ... is given', () => {
    expect(() => fixture.detectChanges()).toThrowError();
  });`
3. When this test is executed, MyComponent is not created properly, therefore I assume that the listener is not attached properly either. However the test cleanup may call destroy of the VirtualScrollComponent internally anyways.
4. As this.onScrollListener has not been defined, the cleanup phase failed causing all subsequent test to fail, too.

-> I could fix this by ensuring that `onScrollListener` is not undefined before removing the listener.