### PR TITLE
feat(bufferAmount): add bufferAmount option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Child component is not a necessity if your item is simple enough. See below.
 | items          | any[]  | The data that builds the templates within the virtual scroll. This is the same data that you'd pass to ngFor. It's important to note that when this data has changed, then the entire virtual scroll is refreshed.
 | childWidth     | number | The minimum width of the item template's cell. This dimension is used to help determine how many cells should be created when initialized, and to help calculate the height of the scrollable area. Note that the actual rendered size of the first cell is used by default if not specified.
 | childHeight    | number | The minimum height of the item template's cell. This dimension is used to help determine how many cells should be created when initialized, and to help calculate the height of the scrollable area. Note that the actual rendered size of the first cell is used by default if not specified.
+| bufferAmount   | number | The the number of elements to be rendered outside of the current container's viewport. Useful when not all elements are the same dimensions.
 | update         | Event  | This event is fired every time `start` or `end` index change and emits list of items from `start` to `end`. The list emitted by this event must be used with `*ngFor` to render the actual list of items within `<virtual-scroll>`
 | change         | Event  | This event is fired every time `start` or `end` index change and emits `ChangeEvent` which of format: `{ start: number, end: number }`
 

--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -72,6 +72,9 @@ export class VirtualScrollComponent implements OnInit, OnDestroy, OnChanges {
   @Input()
   childHeight: number;
 
+  @Input()
+  bufferAmount: number = 0;
+
   @Output()
   update: EventEmitter<any[]> = new EventEmitter<any[]>();
 
@@ -223,6 +226,10 @@ export class VirtualScrollComponent implements OnInit, OnDestroy, OnChanges {
 
     start = !isNaN(start) ? start : -1;
     end = !isNaN(end) ? end : -1;
+    start -= this.bufferAmount;
+    start = Math.max(0, start);
+    end += this.bufferAmount;
+    end = Math.min(items.length, end);
     if (start !== this.previousStart || end !== this.previousEnd) {
 
       // update the scroll list


### PR DESCRIPTION
In our app we have variable height items which means the current algorithm that assumes all elements are the same height doesn't work properly and not all elements are rendered. Using a buffer overflow seems to do the trick to fixing it.

Before:
<img width="338" alt="screen shot 2017-06-06 at 08 55 10" src="https://cloud.githubusercontent.com/assets/6425649/26819317/3b717f78-4a96-11e7-8075-81d7ccd684d6.png">

After:
<img width="334" alt="screen shot 2017-06-06 at 08 55 54" src="https://cloud.githubusercontent.com/assets/6425649/26819324/485a2ad2-4a96-11e7-81d1-7dc2c99439bb.png">

The idea was borrowed from other virtual scroll components such as [ionics `bufferRatio` option](http://ionicframework.com/docs/api/components/virtual-scroll/VirtualScroll/) and [this angularjs directives vs-excess option](https://github.com/kamilkp/angular-vs-repeat)