### PR TITLE
Fixed items.previousValue undefined check in ngOnChanges

### DIFF
--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -117,7 +117,7 @@ export class VirtualScrollComponent implements OnInit, OnDestroy, OnChanges {
     this.previousStart = undefined;
     this.previousEnd = undefined;
     const items = (changes as any).items || {};
-    if ((changes as any).items != undefined && items.previousValue == undefined || items.previousValue.length === 0) {
+    if ((changes as any).items != undefined && items.previousValue == undefined || (items.previousValue != undefined && items.previousValue.length === 0)) {
       this.startupLoop = true;
     }
     this.refresh();


### PR DESCRIPTION
The current ngOnChanges implementation does not check which `Input` property is being changed - it could be that the `childHeight` property is being changed.
As a result, I was getting an exception `Cannot read property 'length' of undefined` -  in this case `items.previousValue.length`.
I have added a check to prevent this exception.