### PR TITLE
[Perf] Run scroll and frame handlers outside of angular zone

### DIFF
--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -88,7 +88,6 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
     if (this._parentScroll === element) {
       return;
     }
-    this.removeParentEventHandlers();
     this._parentScroll = element;
     this.addParentEventHandlers(this._parentScroll);
   }
@@ -194,6 +193,7 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private addParentEventHandlers(parentScroll: Element | Window) {
+    this.removeParentEventHandlers();
     if (parentScroll) {
       this.zone.runOutsideAngular(() => {
         this.disposeScrollHandler =

--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -125,6 +125,12 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
   private disposeScrollHandler: () => void | undefined;
   private disposeResizeHandler: () => void | undefined;
 
+  /** Cache of the last scroll height to prevent setting CSS when not needed. */
+  private lastScrollHeight = -1;
+
+  /** Cache of the last top padding to prevent setting CSS when not needed. */
+  private lastTopPadding = -1;
+
   constructor(
       private readonly element: ElementRef,
       private readonly renderer: Renderer2,
@@ -271,6 +277,11 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
       itemsPerRow = itemsPerRowByCalc;
     }
 
+    if (scrollHeight !== this.lastScrollHeight) {
+      this.renderer.setStyle(this.shimElementRef.nativeElement, 'height', `${scrollHeight}px`);
+      this.lastScrollHeight = scrollHeight;
+    }
+
     return {
       itemCount: itemCount,
       viewWidth: viewWidth,
@@ -313,9 +324,11 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
 
     const topPadding = d.childHeight * Math.ceil(start / d.itemsPerRow) - (d.childHeight * Math.min(start, this.bufferAmount));;
 
-    this.renderer.setStyle(this.shimElementRef.nativeElement, 'height', `${d.scrollHeight}px`);
-    this.renderer.setStyle(this.contentElementRef.nativeElement, 'transform', `translateY(${topPadding}px)`);
-    this.renderer.setStyle(this.contentElementRef.nativeElement, 'webkitTransform', `translateY(${topPadding}px)`);
+    if (topPadding !== this.lastTopPadding) {
+      this.renderer.setStyle(this.contentElementRef.nativeElement, 'transform', `translateY(${topPadding}px)`);
+      this.renderer.setStyle(this.contentElementRef.nativeElement, 'webkitTransform', `translateY(${topPadding}px)`);
+      this.lastTopPadding = topPadding;
+    }
 
     start = !isNaN(start) ? start : -1;
     end = !isNaN(end) ? end : -1;


### PR DESCRIPTION
To improve perf, attach the scroll/frame handlers outside of the zone. Only go back into the zone if there is an actual change to be emitted.

- There is also a slight fix here where we don't attach the host element scroll listener if `[parentScroll]` is supplied.

To highlight the difference in the demo app, I scrolled just a tiny bit so that no actual changes need emitting:

Before:
<img width="848" alt="screen shot 2017-09-16 at 1 40 33 pm" src="https://user-images.githubusercontent.com/702990/30515981-7955480a-9ae7-11e7-841e-1c2eb11fb281.png">

After:
<img width="796" alt="screen shot 2017-09-16 at 1 51 20 pm" src="https://user-images.githubusercontent.com/702990/30515985-964fb2a6-9ae7-11e7-8d0b-b061023bf448.png">

Once a change is emitted, we must do this in the `angular` zone and incurr the change detection, so the difference is only a small reduction in the initial scroll handler time:

Before:
<img width="846" alt="screen shot 2017-09-16 at 2 06 08 pm" src="https://user-images.githubusercontent.com/702990/30516022-4d5c027e-9ae8-11e7-8da5-070d2b3680f9.png">

After:
<img width="932" alt="screen shot 2017-09-16 at 2 06 43 pm" src="https://user-images.githubusercontent.com/702990/30516028-538f04d4-9ae8-11e7-8dd3-4da8383879a1.png">


Fixes #66 

/cc @ghetolay

