### PR TITLE
Prevent jittering scroll-animations & endless animation frames

### DIFF
--- a/dist/virtual-scroll.js
+++ b/dist/virtual-scroll.js
@@ -73,6 +73,7 @@ var VirtualScrollComponent = (function () {
         var d = this.calculateDimensions();
         var scrollTop = (Math.floor(index / d.itemsPerRow) * d.childHeight)
             - (d.childHeight * Math.min(index, this.bufferAmount));
+        var animationRequest;
         if (this.currentTween != undefined)
             this.currentTween.stop();
         this.currentTween = new tween.Tween({ scrollTop: el.scrollTop })
@@ -85,12 +86,15 @@ var VirtualScrollComponent = (function () {
             _this.renderer.setProperty(el, 'scrollTop', data.scrollTop);
             _this.refresh();
         })
+            .onStop(function () {
+            cancelAnimationFrame(animationRequest);
+        })
             .start();
         var animate = function (time) {
             _this.currentTween.update(time);
             if (_this.currentTween._object.scrollTop !== scrollTop) {
                 _this.zone.runOutsideAngular(function () {
-                    requestAnimationFrame(animate);
+                    animationRequest = requestAnimationFrame(animate);
                 });
             }
         };

--- a/dist/virtual-scroll.js
+++ b/dist/virtual-scroll.js
@@ -79,6 +79,9 @@ var VirtualScrollComponent = (function () {
             .to({ scrollTop: scrollTop }, this.scrollAnimationTime)
             .easing(tween.Easing.Quadratic.Out)
             .onUpdate(function (data) {
+            if (isNaN(data.scrollTop)) {
+                return;
+            }
             _this.renderer.setProperty(el, 'scrollTop', data.scrollTop);
             _this.refresh();
         })

--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -175,6 +175,8 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
     let scrollTop = (Math.floor(index / d.itemsPerRow) * d.childHeight)
       - (d.childHeight * Math.min(index, this.bufferAmount));
 
+    let animationRequest;
+
     if (this.currentTween != undefined) this.currentTween.stop()
     this.currentTween = new tween.Tween({ scrollTop: el.scrollTop })
       .to({ scrollTop }, this.scrollAnimationTime)
@@ -186,13 +188,16 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
         this.renderer.setProperty(el, 'scrollTop', data.scrollTop);
         this.refresh();
       })
+      .onStop(() => {
+        cancelAnimationFrame(animationRequest);
+      })
       .start();
 
     const animate = (time?) => {
       this.currentTween.update(time);
       if (this.currentTween._object.scrollTop !== scrollTop) {
         this.zone.runOutsideAngular(() => {
-          requestAnimationFrame(animate);
+            animationRequest = requestAnimationFrame(animate);
         });
       }
     }

--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -180,6 +180,9 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
       .to({ scrollTop }, this.scrollAnimationTime)
       .easing(tween.Easing.Quadratic.Out)
       .onUpdate((data) => {
+        if (isNaN(data.scrollTop)) {
+          return;
+        }
         this.renderer.setProperty(el, 'scrollTop', data.scrollTop);
         this.refresh();
       })


### PR DESCRIPTION
This pull-request checks if the data.scrollTop value is not-a-number. If so, there must not be any animation, because this would cause a scroll to the top which makes the animation jitter.

Furthermore it cancels the requested animation frames after the current tween stops. This prevents endless running animation frames.