### PR TITLE
set disposeResizeHandler instead of disposeScrollHandler

### DIFF
--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -223,7 +223,7 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
         this.disposeScrollHandler =
           this.renderer.listen(parentScroll, 'scroll', this.refreshHandler);
         if (parentScroll instanceof Window) {
-          this.disposeScrollHandler =
+          this.disposeResizeHandler =
             this.renderer.listen('window', 'resize', this.refreshHandler);
         }
       });


### PR DESCRIPTION
I am guessing here, but in `addParentEventHandlers()` the disposeScrollHandler gets set twice if `parentScroll` is a `Window`. My hunch is that in the `if` it is supposed to be setting a disposeResizeHandler instead?