### PR TITLE
Disabled the setTimeout function when throttling value is 0

### DIFF
--- a/src/virtual-scroll.ts
+++ b/src/virtual-scroll.ts
@@ -459,10 +459,15 @@ export class VirtualScrollComponent implements OnInit, OnChanges, OnDestroy {
 				return;
 			}
 
-			timeout = setTimeout(function () {
-				timeout = undefined;
-				func.apply(_this, _arguments);
-			}, wait);
+			if(wait == 0) {
+                func.apply(_this, _arguments);
+			} else {
+                timeout = setTimeout(function () {
+                    timeout = undefined;
+                    func.apply(_this, _arguments);
+                }, wait);
+			}
+
 		};
 
 		return result;


### PR DESCRIPTION

scrollThrottlingTime with a value of 0 still causes small rendering delay. ( I noticed this difference while switching between an old version I was using of this lib and the current version ).

This because calling setTimeout with 0 places the code to execute at the event of the event loop and is not process immediately as we would expect. 

