### PR TITLE
Add scrollLength property to IPageInfo interface

### DIFF
--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -82,11 +82,11 @@ export interface IPageInfo {
 	scrollStartPosition: number;
 	startIndex: number;
 	startIndexWithBuffer: number;
+	scrollLength: number;
 }
 
 export interface IViewport extends IPageInfo {
 	padding: number;
-	scrollLength: number;
 }
 
 @Component({
@@ -185,7 +185,8 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 			scrollEndPosition: pageInfo.scrollEndPosition || 0,
 			maxScrollPosition: pageInfo.maxScrollPosition || 0,
 			startIndexWithBuffer: pageInfo.startIndexWithBuffer || 0,
-			endIndexWithBuffer: pageInfo.endIndexWithBuffer || 0
+			endIndexWithBuffer: pageInfo.endIndexWithBuffer || 0,
+			scrollLength: pageInfo.scrollLength || 0,
 		};
 	}
 
@@ -826,7 +827,8 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 					scrollEndPosition: viewport.scrollEndPosition,
 					startIndexWithBuffer: viewport.startIndexWithBuffer,
 					endIndexWithBuffer: viewport.endIndexWithBuffer,
-					maxScrollPosition: viewport.maxScrollPosition
+					maxScrollPosition: viewport.maxScrollPosition,
+					scrollLength: viewport.scrollLength
 				} : undefined;
 
 
@@ -1300,7 +1302,8 @@ export class VirtualScrollerComponent implements OnInit, OnChanges, OnDestroy {
 			endIndexWithBuffer: endIndexWithBuffer,
 			scrollStartPosition: scrollPosition,
 			scrollEndPosition: scrollPosition + dimensions.viewportLength,
-			maxScrollPosition: dimensions.maxScrollPosition
+			maxScrollPosition: dimensions.maxScrollPosition,
+			scrollLength: dimensions.scrollLength,
 		};
 	}
 


### PR DESCRIPTION
The changes in the pull request will make the scrollLength property available within the viewPortInfo getter. This change will allow you the make use of the scrollLength property within the component which calls the virtual-scroller. 
The problem I faced which made me create these changes is the following. 

Say I have a webpage with a setup something like:
```
HEADER
CONTENT -> virtual-scroller
FOOTER
```
The content section is where I want to use the virtual-scroller. This means I need to use the parent scroll implementation. Which is fine, but the problem with this solution is that the component of virtual-scroller will collapse. This will result in the footer jumping op into the content of the virtual-scroller. With making scrollLength available you can do something like the following:
```
<virtual-scroller
        #scroll
        [items]="items"
        [parentScroll]="scroll.window"
        [enableUnequalChildrenSizes]="true"
        [style]="{'height': scroll.viewPortInfo.scrollLength + 'px'}"
>
        <some-component *ngFor="let tip of scroll.viewPortItems"></some-component>
</virtual-scroller>
```
This solution will allow you the have your content within the virtual scroller without facing the problems of a collapsed virtual-scroller. 

The problem is also visible within the parent scroll demo -> https://rintoj.github.io/ngx-virtual-scroller/parentScroll