### PR TITLE
Fix issue that the container loses focus after pageup or pagedown key press

### DIFF
--- a/src/virtual-scroller.ts
+++ b/src/virtual-scroller.ts
@@ -102,7 +102,8 @@ export interface IViewport extends IPageInfo {
 		'[class.horizontal]': "horizontal",
 		'[class.vertical]': "!horizontal",
 		'[class.selfScroll]': "!parentScroll",
-		'[class.rtl]': "RTL"
+		'[class.rtl]': "RTL",
+		'[attr.tabindex]': "-1",
 	},
 	styles: [`
     :host {


### PR DESCRIPTION
I experience the [issue](https://github.com/whyboris/Video-Hub-App/issues/579) in Video Hub App, which uses ngx-virtual-scroller. After some searches, found a workaround PapaNappa posted years ago: https://github.com/rintoj/ngx-virtual-scroller/issues/213#issuecomment-425849817. The minimum required change to fix the problem in Video Hub App is just adding `tabindex` attribute. Not tested in any other use cases.

There are so many reports about this issue (e.g. https://github.com/rintoj/ngx-virtual-scroller/issues/144, https://github.com/rintoj/ngx-virtual-scroller/issues/213, https://github.com/rintoj/ngx-virtual-scroller/issues/425, https://github.com/whyboris/Video-Hub-App/issues/645, https://github.com/whyboris/Video-Hub-App/issues/646). Why is there no investigation or effort trying to properly identify and fix the problem? It's not like this is rare case and hard to reproduce. Literally, just open Video Hub App with some videos and you can repro.